### PR TITLE
refactor --continue-on-failure feature pr

### DIFF
--- a/catkin_tools/verbs/catkin_build/cli.py
+++ b/catkin_tools/verbs/catkin_build/cli.py
@@ -79,7 +79,7 @@ def prepare_arguments(parser):
         help='Build a given package and those which depend on it, skipping any before it.')
     add('--start-with-this', action='store_true', default=False,
         help='Similar to --start-with, starting with the package containing the current directory.')
-    add('--continue-on-failure', '-c', action='store_true', default=False, dest='robust',
+    add('--continue-on-failure', '-c', action='store_true', default=False,
         help='Try to continue building packages whose dependencies built successfully even if some other requested '
              'packages fail to build.')
 
@@ -220,7 +220,7 @@ def main(opts):
             no_status=opts.no_status,
             lock_install=not opts.no_install_lock,
             no_notify=opts.no_notify,
-            robust=opts.robust
+            continue_on_failure=opts.continue_on_failure
         )
     finally:
         log("[build] Runtime: {0}".format(format_time_delta(time.time() - start)))

--- a/catkin_tools/verbs/catkin_build/executor.py
+++ b/catkin_tools/verbs/catkin_build/executor.py
@@ -45,7 +45,7 @@ class Executor(Thread):
     """Threaded executor for the parallel catkin build jobs"""
     name_prefix = 'build'
 
-    def __init__(self, executor_id, context, comm_queue, job_queue, install_lock, robust=False):
+    def __init__(self, executor_id, context, comm_queue, job_queue, install_lock, continue_on_failure=False):
         super(Executor, self).__init__()
         self.name = self.name_prefix + '-' + str(executor_id + 1)
         self.executor_id = executor_id
@@ -54,7 +54,7 @@ class Executor(Thread):
         self.jobs = job_queue
         self.current_job = None
         self.install_space_lock = install_lock
-        self.shutdown_on_failure = not robust
+        self.shutdown_on_failure = not continue_on_failure
 
     def job_started(self, job):
         self.queue.put(ExecutorEvent(self.executor_id, 'job_started', {}, job.package.name))


### PR DESCRIPTION
I did a few things in this refactor:
- Output the build summary in columns.
- Separated the failures from the successfully built and not built packages in the build summary, putting the failures at the bottom.
- Replaced the use of `robust` throughout with `continue_on_failure` for consistency.
- Refactored the error summary to include a `cat path/to/log/file/for/this/failure` and cleaned up the output, it is still before the build summary, so you have to scroll, but it provides useful (IMO) information about the failed package.
- I added a one line summary at the very end.

This is what it looks like on my Mac:

![screen shot 2015-02-03 at 7 44 14 pm](https://cloud.githubusercontent.com/assets/100427/6034938/968b386c-abde-11e4-9569-442d7b398586.png)

![screen shot 2015-02-03 at 7 43 42 pm](https://cloud.githubusercontent.com/assets/100427/6034939/9c253ae8-abde-11e4-85ad-7496f389329d.png)

![screen shot 2015-02-03 at 7 43 05 pm](https://cloud.githubusercontent.com/assets/100427/6034940/a0b3973a-abde-11e4-9f2a-739157cb86d6.png)

As you can see, this produces a lot of output still on a large workspace (this is indigo-desktop), but I think this is a reasonable compromise between the approaches.

I thought about striking the "error summary" completely, but otherwise it is hard to quickly access information like how to run the thing that failed or even how to cat the log for that package.

P.S. In case you didn't know, if you merge this it will automatically update this pull request: https://github.com/catkin/catkin_tools/pull/138
